### PR TITLE
procd: Allow setting user and/or group wifi-presence runs as

### DIFF
--- a/net/wifi-presence/files/wifi-presence.conf
+++ b/net/wifi-presence/files/wifi-presence.conf
@@ -44,3 +44,10 @@ config wifi-presence main
 	## Set the MQTT topic prefix used by Home Assistant.
 	## Default is 'homeassistant' (also Home Assistant's default value).
 	# option hassPrefix 'homeassistant'
+
+	## Set the user and group that runs the wifi-presence process.
+	## This can be useful to change if using seccomp, causing the hostapd
+	## socket files to be owned by the 'network' user and group.
+	## Default is root / root.
+	# option runAsUser 'network'
+	# option runAsGroup 'network'

--- a/net/wifi-presence/files/wifi-presence.init
+++ b/net/wifi-presence/files/wifi-presence.init
@@ -26,6 +26,9 @@ start_service() {
         local sockDir
         local verbose
 
+        local runAsUser
+        local runAsGroup
+
         config_get apName main apName
         config_get debounce main debounce
         config_get hassAutodiscovery main hassAutodiscovery
@@ -38,6 +41,9 @@ start_service() {
         config_get mqttPrefix main mqttPrefix
         config_get sockDir main sockDir
         config_get_bool verbose main verbose
+
+        config_get runAsUser main runAsUser
+        config_get runAsGroup main runAsGroup
 
         procd_open_instance
 
@@ -54,6 +60,9 @@ start_service() {
         [ -n "${mqttPrefix}" ] && procd_append_param command "-mqtt.prefix=${mqttPrefix}"
         [ -n "${sockDir}" ] && procd_append_param command "-sockDir=${sockDir}"
         [ -n "${verbose}" ] && procd_append_param command "-verbose=${verbose}"
+
+        [ -n "${runAsUser}" ] && procd_set_param user "${runAsUser}"
+        [ -n "${runAsGroup}" ] && procd_set_param group "${runAsGroup}"
 
         procd_set_param file "/etc/config/${CONF}"
         procd_set_param stdout 1


### PR DESCRIPTION
This addresses an issue reported in #3 where the hostapd socket files
are owned by a different user/group than wifi-presence is being run as.
An error occurs at wifi-presence startup because of lack of permissions
accessing the sockets.
Likely caused by use of seccomp or similar, triggering hostapd to be run
as 'network' user/group ([source]).

This adds the ability to configure the user and/or group that runs the
wifi-presence process in the config file.

[source]: https://github.com/openwrt/openwrt/blob/ec6293febc244d187e71a6e54f44920be679cde4/package/network/services/hostapd/files/wpad.init#L35-L36