### PR TITLE
hostapd: Handle new AP-STA-CONNECTED syntax

### DIFF
--- a/cmd/wifi-presence/main.go
+++ b/cmd/wifi-presence/main.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"io/fs"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/signal"
@@ -196,7 +196,7 @@ func run(ctx context.Context, appName string) error {
 
 	// Set all logging to /dev/null unless verbose flag was set.
 	if !args.verbose {
-		log.SetOutput(ioutil.Discard)
+		log.SetOutput(io.Discard)
 	}
 
 	// Create MQTT client.

--- a/internal/hostapd/event.go
+++ b/internal/hostapd/event.go
@@ -38,10 +38,18 @@ func parseEvent(msg string) (Event, error) {
 
 	switch {
 	case strings.HasPrefix(msg, eventAPStaConnected):
-		// Station connect event. Example:
-		// "<3>AP-STA-CONNECTED 04:ab:00:12:34:56"
+		// Station connect event. Examples:
+		// AP-STA-CONNECTED 04:ab:00:12:34:56
+		// AP-STA-CONNECTED 04:ab:00:12:34:56 auth_alg=open
 
 		mac := strings.TrimSpace(strings.TrimPrefix(msg, eventAPStaConnected))
+
+		// Strip any trailing data after the MAC address.
+		// https://github.com/awilliams/wifi-presence/issues/12
+		if len(mac) > macLength {
+			mac = mac[:macLength]
+		}
+
 		if !isMAC(mac) {
 			return nil, fmt.Errorf("invalid MAC address %q", mac)
 		}

--- a/internal/hostapd/event_test.go
+++ b/internal/hostapd/event_test.go
@@ -17,6 +17,14 @@ func TestParseEvent(t *testing.T) {
 			},
 		},
 		{
+			name:  "connect with algo",
+			input: "AP-STA-CONNECTED 04:ab:00:12:34:56 auth_alg=open",
+			expected: EventStationConnect{
+				raw: "AP-STA-CONNECTED 04:ab:00:12:34:56 auth_alg=open",
+				MAC: "04:ab:00:12:34:56",
+			},
+		},
+		{
 			name:  "connect-lvl1",
 			input: "<1>AP-STA-CONNECTED 04:ab:00:12:34:56",
 			expected: EventStationConnect{

--- a/internal/hostapd/mac.go
+++ b/internal/hostapd/mac.go
@@ -6,6 +6,8 @@ import (
 
 var macRegexp = regexp.MustCompile(`^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$`)
 
+const macLength = 2*6 + 5
+
 // validateMAC returns an false if v is not a valid MAC address
 // in XX:XX:XX:XX:XX:XX format.
 func isMAC(v string) bool {

--- a/internal/presence/daemon.go
+++ b/internal/presence/daemon.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"strings"
 	"sync"
@@ -126,7 +126,7 @@ func NewDaemon(opts ...Opt) (*Daemon, error) {
 	}
 
 	if d.logger == nil {
-		d.logger = log.New(ioutil.Discard, "", 0)
+		d.logger = log.New(io.Discard, "", 0)
 	}
 	if d.db == nil {
 		d.db = newDebouncer(5 * time.Second)


### PR DESCRIPTION
Newer versions of hostapd include additional data in the AP-STA-CONNECTED message. Example:

    AP-STA-CONNECTED 04:ab:00:12:34:56 auth_alg=open

This change removes any trailing data before attempting to parse the MAC address from these messages.

Fixes #12