### PR TITLE
Workaround for truncated status read

### DIFF
--- a/internal/hostapd/ctrl.go
+++ b/internal/hostapd/ctrl.go
@@ -43,7 +43,7 @@ func newCtrl(cn *conn, rTimeout, wTimeout time.Duration) (*ctrl, error) {
 		readTimeout:  rTimeout,
 		writeTimeout: wTimeout,
 		conn:         cn,
-		buf:          make([]byte, 1024),
+		buf:          make([]byte, 2*1024),
 	}
 	if err := c.ping(); err != nil {
 		return nil, fmt.Errorf("ping error: %w", err)

--- a/internal/hostapd/ctrl.go
+++ b/internal/hostapd/ctrl.go
@@ -43,7 +43,9 @@ func newCtrl(cn *conn, rTimeout, wTimeout time.Duration) (*ctrl, error) {
 		readTimeout:  rTimeout,
 		writeTimeout: wTimeout,
 		conn:         cn,
-		buf:          make([]byte, 2*1024),
+		// It's unclear what the correct size to make this buffer is.
+		// See <https://github.com/awilliams/wifi-presence/issues/30> for details.
+		buf:          make([]byte, 4*1024),
 	}
 	if err := c.ping(); err != nil {
 		return nil, fmt.Errorf("ping error: %w", err)


### PR DESCRIPTION
This is a workaround for
https://github.com/awilliams/wifi-presence/issues/30. Ideally we'd somehow verify that we have actually read the full response, but I don't see a mechanism for doing that. See my notes here for details: <https://github.com/awilliams/wifi-presence/issues/30#issuecomment-3152061321>.